### PR TITLE
Remove animations from Contact Us section

### DIFF
--- a/contact-animations.js
+++ b/contact-animations.js
@@ -18,18 +18,18 @@ document.addEventListener("DOMContentLoaded", function () {
  */
 function initContactAnimations() {
   // Initialize GSAP for smoother animations if available
-  if (typeof gsap !== "undefined") {
-    initContactGsapAnimations();
-  } else {
-    // Fallback to standard animations if GSAP is not available
-    initContactStandardAnimations();
-  }
+  // if (typeof gsap !== "undefined") {
+  //   initContactGsapAnimations();
+  // } else {
+  //   // Fallback to standard animations if GSAP is not available
+  //   initContactStandardAnimations();
+  // }
 
   // Add scroll reveal effects
-  initContactScrollReveal();
+  // initContactScrollReveal();
 
   // Add hover effects
-  initContactHoverEffects();
+  // initContactHoverEffects();
 
   // Add form interactions
   enhanceContactForm();
@@ -131,13 +131,13 @@ function enhanceGetInTouchCard() {
 
   // Performance optimization: Use classList operations in batch
   // Add all classes at once rather than multiple separate operations
-  getInTouchCard.classList.add(
-    "contact-card-enhanced",
-    "hover:shadow-xl",
-    "hover:-translate-y-1",
-    "transition-all",
-    "duration-300"
-  );
+  // getInTouchCard.classList.add(
+  //   "contact-card-enhanced",
+  //   "hover:shadow-xl",
+  //   "hover:-translate-y-1",
+  //   "transition-all",
+  //   "duration-300"
+  // );
 
   // Enhance corner elements with subtle animation using a single operation
   document
@@ -161,26 +161,26 @@ function enhanceGetInTouchCard() {
     const icon = container.querySelector(".fas");
     if (icon) {
       // Use CSS classes instead of inline styles for better performance
-      icon.classList.add(
-        "icon-enhanced",
-        "transition-all",
-        "duration-300",
-        "group-hover:text-secondary",
-        "relative",
-        "z-10"
-      );
+      // icon.classList.add(
+      //   "icon-enhanced",
+      //   "transition-all",
+      //   "duration-300",
+      //   "group-hover:text-secondary",
+      //   "relative",
+      //   "z-10"
+      // );
     }
   });
 
   // Enhance social icons with optimized class application
   getInTouchCard.querySelectorAll(".social-icon").forEach((icon) => {
-    icon.classList.add(
-      "social-icon-enhanced",
-      "relative",
-      "z-30",
-      "transition-all",
-      "duration-300"
-    );
+    // icon.classList.add(
+    //   "social-icon-enhanced",
+    //   "relative",
+    //   "z-30",
+    //   "transition-all",
+    //   "duration-300"
+    // );
   });
 }
 
@@ -196,17 +196,17 @@ function enhanceMapCard() {
   if (!mapCard || !iframe) return;
 
   // Add hover effect
-  mapCard.addEventListener("mouseenter", function () {
-    this.style.transform = "translateY(-5px)";
-    this.style.boxShadow = "0 15px 30px rgba(0, 0, 0, 0.15)";
-    iframe.style.transform = "scale(1.02)";
-  });
+  // mapCard.addEventListener("mouseenter", function () {
+  //   this.style.transform = "translateY(-5px)";
+  //   this.style.boxShadow = "0 15px 30px rgba(0, 0, 0, 0.15)";
+  //   iframe.style.transform = "scale(1.02)";
+  // });
 
-  mapCard.addEventListener("mouseleave", function () {
-    this.style.transform = "";
-    this.style.boxShadow = "";
-    iframe.style.transform = "";
-  });
+  // mapCard.addEventListener("mouseleave", function () {
+  //   this.style.transform = "";
+  //   this.style.boxShadow = "";
+  //   iframe.style.transform = "";
+  // });
 
   // Add loading animation
   iframe.addEventListener("load", function () {
@@ -216,7 +216,7 @@ function enhanceMapCard() {
 
   // Set initial state
   iframe.style.opacity = "0.7";
-  iframe.style.transition = "all 0.5s ease";
+  // iframe.style.transition = "all 0.5s ease";
 }
 
 // Remove duplicate animations that are already in initContactGsapAnimations function
@@ -407,16 +407,16 @@ function enhanceContactForm() {
       // Add a success animation
       const submitButton = this.querySelector('button[type="submit"]');
       if (submitButton) {
-        submitButton.innerHTML = '<i class="fas fa-check"></i> Message Sent!';
-        submitButton.classList.add("success-animation");
+        // submitButton.innerHTML = '<i class="fas fa-check"></i> Message Sent!';
+        // submitButton.classList.add("success-animation");
 
         // Reset form after delay
-        setTimeout(() => {
-          this.reset();
-          submitButton.innerHTML = "Send Message";
-          submitButton.classList.remove("success-animation");
-          formInputs.forEach((input) => input.classList.remove("has-value"));
-        }, 3000);
+        // setTimeout(() => {
+        //   this.reset();
+        //   submitButton.innerHTML = "Send Message";
+        //   submitButton.classList.remove("success-animation");
+        //   formInputs.forEach((input) => input.classList.remove("has-value"));
+        // }, 3000);
       }
     });
   }
@@ -458,7 +458,7 @@ document.addEventListener("DOMContentLoaded", function () {
       background: linear-gradient(to right, #4CAF50, #8BC34A) !important;
     }
   `;
-  document.head.appendChild(style);
+  // document.head.appendChild(style);
 });
 
 // Add proper error handling for animations

--- a/contact-styles.css
+++ b/contact-styles.css
@@ -7,7 +7,7 @@
 #contact .glassmorphism {
   position: relative;
   overflow: hidden;
-  transition: all 0.3s ease;
+  /* transition: all 0.3s ease; */
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
@@ -23,17 +23,17 @@
 /* Desktop hover effects */
 @media (hover: hover) and (pointer: fine) {
   #contact .glassmorphism:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15);
-    border-color: rgba(255, 255, 255, 0.3);
+    /* transform: translateY(-5px); */
+    /* box-shadow: 0 15px 30px rgba(0, 0, 0, 0.15); */
+    /* border-color: rgba(255, 255, 255, 0.3); */
   }
 }
 
 /* Active state for mobile touch */
 #contact .glassmorphism:active {
-  transform: scale(0.98);
-  transition: all 0.2s ease;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+  /* transform: scale(0.98); */
+  /* transition: all 0.2s ease; */
+  /* box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1); */
 }
 
 /* Reduce motion for users who prefer it */
@@ -45,7 +45,7 @@
   #contact .glassmorphism:hover,
   #contact .glassmorphism:active {
     transform: none;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1); /* Ensure box-shadow is reset */
   }
 }
 
@@ -124,15 +124,15 @@
   border-radius: 50%;
   background-color: #f8f9fa;
   color: #333;
-  transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  /* transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275); */
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 #contact .social-icon:hover {
-  transform: translateY(-3px);
-  background: linear-gradient(to right, #e74c3c, #f39c12);
-  color: white;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  /* transform: translateY(-3px); */
+  /* background: linear-gradient(to right, #e74c3c, #f39c12); */
+  /* color: white; */
+  /* box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2); */
 }
 
 /* Fix for icons in contact info */
@@ -142,28 +142,28 @@
   justify-content: center;
   background: rgba(255, 255, 255, 0.2);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
+  /* transition: all 0.3s ease; */
 }
 
 #contact .flex-shrink-0 i {
   font-size: 1rem;
   color: #e74c3c;
-  transition: all 0.3s ease;
+  /* transition: all 0.3s ease; */
 }
 
 #contact .group-hover\:text-secondary {
-  transition: color 0.3s ease;
+  /* transition: color 0.3s ease; */
 }
 
 #contact .group-hover\:scale-110 {
-  transition: transform 0.3s ease;
+  /* transition: transform 0.3s ease; */
 }
 #contact .flex-col .glassmorphism:first-child .fas,
 #contact .flex-col .glassmorphism:first-child .fab,
 #contact .flex-col .glassmorphism:first-child i {
   color: var(--primary-color, #e74c3c);
   font-size: 1.2rem;
-  transition: all 0.3s ease;
+  /* transition: all 0.3s ease; */
   display: inline-block !important;
   visibility: visible !important;
   opacity: 1 !important;
@@ -214,11 +214,11 @@
   height: 300px;
   border: none;
   display: block;
-  transition: all 0.3s ease;
+  /* transition: all 0.3s ease; */
 }
 
 #contact .flex-col .glassmorphism:last-child:hover iframe {
-  transform: scale(1.02);
+  /* transform: scale(1.02); */
 }
 
 /* Responsive adjustments */
@@ -281,6 +281,7 @@
 }
 
 /* Add subtle animation to the map card */
+/*
 #contact .flex-col .glassmorphism:last-child {
   position: relative;
   overflow: hidden;
@@ -303,7 +304,7 @@
 #contact .flex-col .glassmorphism:last-child:hover::before {
   opacity: 1;
 }
-
+*/
 /* Fix for social icons in Get In Touch card */
 #contact .social-icon-container {
   position: relative;


### PR DESCRIPTION
This commit removes all JavaScript and CSS animations from the Contact Us section.

- Modified `contact-animations.js` to disable animation initializations, hover effects, scroll effects, and dynamic CSS injection for animations.
- Modified `contact-styles.css` to remove CSS transitions, transforms, and animation-related pseudo-elements from various elements within the contact section.

The goal was to eliminate all motion and visual effects previously present in this section.